### PR TITLE
refactor:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ edition = "2021"
 arrayref = "0.3"
 arrayvec = "0.7"
 blake3 = "1"
+futures = { version = "0.3", features = [], default-features = false, optional = true }
 tokio = { version = "1", features = [], default-features=false, optional = true }
 
 [features]
 # todo: remove before merge
 default = ["tokio_io"]
-tokio_io = ["tokio"]
+tokio_io = ["tokio", "futures"]
 
 [dev-dependencies]
 lazy_static = "1.3"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -460,12 +460,13 @@ impl<T, O> fmt::Debug for DecoderShared<T, O> {
 mod tokio_io {
 
     use super::{DecoderShared, Hash, NextRead};
+    use futures::{future, ready};
     use std::{
         cmp,
         convert::TryInto,
         io,
         pin::Pin,
-        task::{ready, Context, Poll},
+        task::{Context, Poll},
     };
     use tokio::io::{AsyncRead, ReadBuf};
 
@@ -853,7 +854,7 @@ mod tokio_io {
         /// we are at the start.
         pub async fn read_size(&mut self) -> io::Result<u64> {
             if let SliceDecoderState::Reading(state) = &mut self.0 {
-                std::future::poll_fn(|cx| state.shared.poll_read_header(cx)).await?;
+                future::poll_fn(|cx| state.shared.poll_read_header(cx)).await?;
             }
             Ok(match &self.0 {
                 SliceDecoderState::Reading(state) => state.content_len().unwrap(),


### PR DESCRIPTION
add futures dependency to avoid having to use std::uture::poll_fn and std::task::ready!